### PR TITLE
dependencies should not be a child of galaxy_info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,6 @@ galaxy_info:
   min_ansible_version: 1.7
   categories:
     - cloud
-  dependencies: []
   platforms:
     - name: Ubuntu
       versions:
@@ -20,4 +19,5 @@ galaxy_info:
       versions:
         - 6
         - 7
+dependencies: []
 


### PR DESCRIPTION
Getting a `KeyError: 'dependencies'` when pulling from github instead of galaxy.

Requirements.yml:

``` yaml
- src: https://github.com/openstack-ansible-galaxy/openstack-keystone.git
  name: keystone
```

```
$ ansible-galaxy install -r requirements.yml --ignore-errors --force
- executing: git clone https://github.com/openstack-ansible-galaxy/openstack-keystone.git keystone
- executing: git archive --prefix=keystone/ --output=/tmp/tmp9PkYEz.tar HEAD
- extracting keystone to roles/keystone
- keystone was installed successfully
Traceback (most recent call last):
  File "/home/badi/github.iu.edu/futuresystems/india-kilo-provisioning-tests/venv/bin/ansible-galaxy", line 959, in <module>
    main()
  File "/home/badi/github.iu.edu/futuresystems/india-kilo-provisioning-tests/venv/bin/ansible-galaxy", line 953, in main
    fn(args, options, parser)
  File "/home/badi/github.iu.edu/futuresystems/india-kilo-provisioning-tests/venv/bin/ansible-galaxy", line 845, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies
```

The fix is, described at ansible/ansible#8892, is that `dependencies` should not be a child of `galaxy_info` in `meta/main.yml`.
