### PR TITLE
Kilo on Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python: "2.7"
 
 before_install:
   # Make sure everything's up to date.
-  - sudo apt-get install python-software-properties
-  - sudo add-apt-repository -y cloud-archive:icehouse
+  - sudo apt-get install -y python-software-properties
+  - sudo add-apt-repository -y cloud-archive:kilo
   - sudo apt-get update -qq
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,10 @@ keystone_default_region: regionOne
 # Database
 keystone_database_url: sqlite:////var/lib/keystone/keystone.db
 
+# Memcached
+keystone_memcached_servers:
+  - "localhost"
+
 # Misc
 keystone_api_retries: 3
 keystone_api_retries_delay: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ keystone_default_region: RegionOne
 
 # Database
 keystone_database_url: sqlite:////var/lib/keystone/keystone.db
+keystone_remove_sqlite_db: no
 
 # Memcached
 keystone_memcached_servers:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,4 @@ keystone_api_version: v2.0
 keystone_api_retries: 3
 keystone_api_retries_delay: 5
 keystone_verbose: no
+keystone_run_sanity_check: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,14 @@ keystone_database_url: sqlite:////var/lib/keystone/keystone.db
 keystone_memcached_servers:
   - "localhost"
 
+# WSGI
+keystone_cgibin_dir: /var/www/cgi-bin/keystone
+keystone_wsgi_main_name: main
+keystone_wsgi_admin_name: admin
+keystone_upstream_wsgi_components:
+  "http://git.openstack.org/cgit/openstack/keystone/plain/httpd/\
+  keystone.py?h=stable/kilo"
+
 # Misc
 keystone_api_version: v2.0
 keystone_api_retries: 3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,3 +45,4 @@ keystone_memcached_servers:
 # Misc
 keystone_api_retries: 3
 keystone_api_retries_delay: 5
+keystone_verbose: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,7 @@ keystone_memcached_servers:
   - "localhost"
 
 # Misc
+keystone_api_version: v2.0
 keystone_api_retries: 3
 keystone_api_retries_delay: 5
 keystone_verbose: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ keystone_users: []
 keystone_roles: []
 keystone_services: []
 keystone_endpoints: []
-keystone_default_region: regionOne
+keystone_default_region: RegionOne
 
 # Database
 keystone_database_url: sqlite:////var/lib/keystone/keystone.db

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -29,7 +29,11 @@
   delay: "{{ keystone_api_retries_delay }}"
 
 - name: Use WSGI
-  service: name={{ keystone_service }} state=stopped
+  service: name={{ keystone_service }} state=stopped 
   service: name={{ webserver_service }} state=restarted
 
+- name: Enable Memcached
+  service: name={{ memcached_service }} enabled=yes
 
+- name: Start Memcached
+  service: name={{ memcached_service }} state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -27,3 +27,9 @@
 - name: Restart Keystone
   service: name={{ keystone_service }} state=restarted
 
+- name: Sync Keystone database
+  command: keystone-manage db_sync
+  sudo: yes
+  sudo_user: keystone
+  retries: "{{ keystone_api_retries }}"
+  delay: "{{ keystone_api_retries_delay }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,6 +18,9 @@
 # limitations under the License.
 #
 
+- name: Stop Keystone
+  service: name={{ keystone_service }} state=stopped
+
 - name: Start Keystone
   service: name={{ keystone_service }} state=started
 
@@ -33,3 +36,13 @@
   sudo_user: keystone
   retries: "{{ keystone_api_retries }}"
   delay: "{{ keystone_api_retries_delay }}"
+
+- name: Use WSGI
+  # the particular ordering below is critical. Keystone must be
+  # started AFTER apache is reloaded in order to use WSGI otherwise it
+  # defaults to the eventlet and still claims the ports, causing the
+  # webserver to fail on reload
+  service: name={{ keystone_service }} state=stopped
+  service: name={{ webserver_service }} state=restarted
+  service: name={{ keystone_service }} state=restarted
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -27,14 +27,3 @@
 - name: Restart Keystone
   service: name={{ keystone_service }} state=restarted
 
-- name: Sync Keystone database
-  command: keystone-manage db_sync
-  sudo: yes
-  sudo_user: keystone
-  register: result
-  until: not result|failed
-  retries: "{{ keystone_api_retries }}"
-  delay: "{{ keystone_api_retries_delay }}"
-  notify:
-    - Restart Keystone
-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -29,10 +29,6 @@
   delay: "{{ keystone_api_retries_delay }}"
 
 - name: Use WSGI
-  # the particular ordering below is critical. Keystone must be
-  # started AFTER apache is reloaded in order to use WSGI otherwise it
-  # defaults to the eventlet and still claims the ports, causing the
-  # webserver to fail on reload
   service: name={{ keystone_service }} state=stopped
   service: name={{ webserver_service }} state=restarted
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -37,3 +37,9 @@
 
 - name: Start Memcached
   service: name={{ memcached_service }} state=restarted
+
+- name: Enable Apache
+  service: name={{ webserver_service }} enabled=yes
+
+- name: Start Apache
+  service: name={{ webserver_service }} state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -21,15 +21,6 @@
 - name: Stop Keystone
   service: name={{ keystone_service }} state=stopped
 
-- name: Start Keystone
-  service: name={{ keystone_service }} state=started
-
-- name: Reload Keystone
-  service: name={{ keystone_service }} state=reloaded
-
-- name: Restart Keystone
-  service: name={{ keystone_service }} state=restarted
-
 - name: Sync Keystone database
   command: keystone-manage db_sync
   sudo: yes
@@ -44,5 +35,5 @@
   # webserver to fail on reload
   service: name={{ keystone_service }} state=stopped
   service: name={{ webserver_service }} state=restarted
-  service: name={{ keystone_service }} state=restarted
+
 

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -1,8 +1,7 @@
 ---
 
 #
-# Copyright (c) 2015 Davide Guerri <davide.guerri@gmail.com>
-#
+# Copyright (c) 2015 Badi' Abdul-Wahid <adbulwahidc@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,23 +17,12 @@
 # limitations under the License.
 #
 
-- meta: flush_handlers
-
-- include: facts.yml
-- include: packages.yml
-- include: configuration.yml
-- include: wsgi.yml
-
-- meta: flush_handlers
-
-- name: Ensure that the Keystone service is stopped
-  service:
-    name={{ keystone_service }}
-    state=stopped
-
-- include: maintenance.yml
-- include: endpoints.yml
-- include: tenants.yml
-- include: users.yml
-- include: roles.yml
-- include: cleanup.yml
+- name: CLEANUP Disable authentication token mechanism
+  replace:
+    dest="/etc/keystone/keystone-paste.ini"
+    regexp="^(\[{{ item }}\]\n(?:[#][\S\t ]*\n)*pipeline[ ]*=[ ]*[\S\t ]*)admin_token_auth[\t ]*([\S\t ]*)$"
+    replace="\1\2"
+  with_items:
+    - "pipeline:public_api"
+    - "pipeline:admin_api"
+    - "pipeline:api_v3"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -28,6 +28,21 @@
     - section:   DEFAULT
       option:    admin_token
       value:     "{{ keystone_admin_token }}"
+    - section:   DEFAULT
+      option:    log_dir
+      value:     "{{ keystone_log_dir }}"
+    - section:   DEFAULT
+      option:    admin_bind_host
+      value:     "{{ keystone_admin_bind_host }}"
+    - section:   DEFAULT
+      option:    admin_port
+      value:     "{{ keystone_admin_port }}"
+    - section:   DEFAULT
+      option:    public_bind_host
+      value:     "{{ keystone_bind_host }}"
+    - section:   DEFAULT
+      option:    public_port
+      value:     "{{ keystone_port }}"
     - section:   database
       option:    connection
       value:     "{{ keystone_database_url }}"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -54,7 +54,9 @@
       option:    driver
       value:     keystone.contrib.revoke.backends.sql.Revoke
 
-  notify: Sync Keystone database
+  notify:
+    - Sync Keystone database
+    - Start Apache
 
 - name: Configure keystone to be verbose
   when: keystone_verbose
@@ -64,5 +66,7 @@
     option=verbose
     value=True
   when: keystone_verbose
-  notify: Sync Keystone database
+  notify:
+    - Sync Keystone database
+    - Start Apache
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -52,5 +52,6 @@
     section=DEFAULT
     option=verbose
     value=True
+  when: keystone_verbose
   notify: Sync Keystone database
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -33,7 +33,7 @@
       value:     "{{ keystone_database_url }}"
     - section:   memcache
       option:    servers
-      value:     "{{ keystone_memcache_server }}"
+      value:     "{{ ','.join(keystone_memcached_servers) }}"
     - section:   token
       option:    provider
       value:     keystone.token.providers.uuid.Provider

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -25,9 +25,11 @@
     option="{{ item.option }}"
     value="{{ item.value }}"
   with_items:
+
     - section:   DEFAULT
       option:    admin_token
       value:     "{{ keystone_admin_token }}"
+
     - section:   DEFAULT
       option:    log_dir
       value:     "{{ keystone_log_dir }}"
@@ -35,18 +37,23 @@
     - section:   database
       option:    connection
       value:     "{{ keystone_database_url }}"
+
     - section:   memcache
       option:    servers
       value:     "{{ ','.join(keystone_memcached_servers) }}"
+
     - section:   token
       option:    provider
       value:     keystone.token.providers.uuid.Provider
+
     - section:   token
       option:    driver
       value:     keystone.token.persistence.backends.memcache.Token
+
     - section:   revoke
       option:    driver
       value:     keystone.contrib.revoke.backends.sql.Revoke
+
   notify: Sync Keystone database
 
 - name: Configure keystone to be verbose

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -43,7 +43,7 @@
     - section:   revoke
       option:    driver
       value:     keystone.contrib.revoke.backends.sql.Revoke
-  register: keystone_configured
+  notify: Sync Keystone database
 
 - name: Configure keystone to be verbose
   when: keystone_verbose
@@ -52,16 +52,5 @@
     section=DEFAULT
     option=verbose
     value=True
-  register: keystone_set_to_verbose
+  notify: Sync Keystone database
 
-
-- name: Sync Keystone database
-  shell: sudo su -s /bin/sh -c "keystone-manage db_sync" keystone
-
-  # command: keystone-manage db_sync
-  # sudo: yes
-  # sudo_user: keystone
-  # retries: "{{ keystone_api_retries }}"
-  # delay: "{{ keystone_api_retries_delay }}"
-  # when: keystone_configured.changed
-  # when: keystone_set_to_verbose.changed

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -31,18 +31,7 @@
     - section:   DEFAULT
       option:    log_dir
       value:     "{{ keystone_log_dir }}"
-    - section:   DEFAULT
-      option:    admin_bind_host
-      value:     "{{ keystone_admin_bind_host }}"
-    - section:   DEFAULT
-      option:    admin_port
-      value:     "{{ keystone_admin_port }}"
-    - section:   DEFAULT
-      option:    public_bind_host
-      value:     "{{ keystone_bind_host }}"
-    - section:   DEFAULT
-      option:    public_port
-      value:     "{{ keystone_port }}"
+
     - section:   database
       option:    connection
       value:     "{{ keystone_database_url }}"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -21,9 +21,9 @@
 - name: Configure keystone
   ini_file:
     dest=/etc/keystone/keystone.conf
-    section={{ item.section }}
-    option={{ item.option }}
-    value={{ item.value }}
+    section="{{ item.section }}"
+    option="{{ item.option }}"
+    value="{{ item.value }}"
   with_items:
     - section:   DEFAULT
       option:    admin_token

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -18,44 +18,50 @@
 # limitations under the License.
 #
 
-- name: Configure Keystone
-  ini_file: >
+- name: Configure keystone
+  ini_file:
     dest=/etc/keystone/keystone.conf
-    section="{{ item.section }}"
-    option="{{ item.option }}"
-    value="{{ item.value }}"
+    section={{ item.section }}
+    option={{ item.option }}
+    value={{ item.value }}
   with_items:
-    - section:  DEFAULT
-      option:   admin_token
-      value:    "{{ keystone_admin_token }}"
-    - section:  DEFAULT
-      option:   log_dir
-      value:    "{{ keystone_log_dir }}"
-    - section:  DEFAULT
-      option:   admin_bind_host
-      value:    "{{ keystone_admin_bind_host }}"
-    - section:  DEFAULT
-      option:   admin_port
-      value:    "{{ keystone_admin_port }}"
-    - section:  DEFAULT
-      option:   public_bind_host
-      value:    "{{ keystone_bind_host }}"
-    - section:  DEFAULT
-      option:   public_port
-      value:    "{{ keystone_port }}"
-  notify:
-    - Restart Keystone
+    - section:   DEFAULT
+      option:    admin_token
+      value:     "{{ keystone_admin_token }}"
+    - section:   database
+      option:    connection
+      value:     "{{ keystone_database_url }}"
+    - section:   memcache
+      option:    servers
+      value:     "{{ keystone_memcache_server }}"
+    - section:   token
+      option:    provider
+      value:     keystone.token.providers.uuid.Provider
+    - section:   token
+      option:    driver
+      value:     keystone.token.persistence.backends.memcache.Token
+    - section:   revoke
+      option:    driver
+      value:     keystone.contrib.revoke.backends.sql.Revoke
+  register: keystone_configured
 
-- name: Configure Keystone database
-  ini_file: >
+- name: Configure keystone to be verbose
+  when: keystone_verbose
+  ini_file:
     dest=/etc/keystone/keystone.conf
-    section="{{ item.section }}"
-    option="{{ item.option }}"
-    value="{{ item.value }}"
-  with_items:
-    - section: database
-      option: connection
-      value: "{{ keystone_database_url }}"
-  notify:
-    - Sync Keystone database
-    - Restart Keystone
+    section=DEFAULT
+    option=verbose
+    value=True
+  register: keystone_set_to_verbose
+
+
+- name: Sync Keystone database
+  shell: sudo su -s /bin/sh -c "keystone-manage db_sync" keystone
+
+  # command: keystone-manage db_sync
+  # sudo: yes
+  # sudo_user: keystone
+  # retries: "{{ keystone_api_retries }}"
+  # delay: "{{ keystone_api_retries_delay }}"
+  # when: keystone_configured.changed
+  # when: keystone_set_to_verbose.changed

--- a/tasks/endpoints.yml
+++ b/tasks/endpoints.yml
@@ -24,7 +24,7 @@
     name="{{ item.name }}"
     service_type="{{ item.service_type }}"
     description="{{ item.description|default('Not provided') }}"
-    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/v2.0"
+    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/{{ keystone_api_version }}"
     token="{{ keystone_admin_token }}"
     state="{{ item.state|default('present') }}"
   with_items: keystone_services
@@ -36,7 +36,7 @@
     public_url="{{ item.public_url }}"
     internal_url="{{ item.internal_url }}"
     admin_url="{{ item.admin_url }}"
-    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/v2.0"
+    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/{{ keystone_api_version }}"
     token="{{ keystone_admin_token }}"
     state="{{ item.state|default('present') }}"
   with_items: keystone_endpoints

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -18,10 +18,10 @@
 #
 
 
-- name: Set service facts
+- name: Set service facts for Debian family
   set_fact: keystone_service="keystone"
   when: ansible_os_family == 'Debian'
 
-- name: Set service facts
+- name: Set service facts for RedHat family
   set_fact: keystone_service="openstack-keystone"
   when: ansible_os_family == 'RedHat'

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -22,6 +22,14 @@
   set_fact: keystone_service="keystone"
   when: ansible_os_family == 'Debian'
 
+- name: Set service facts for Debian family
+  set_fact: webserver_service="apache2"
+  when: ansible_os_family == 'Debian'
+
 - name: Set service facts for RedHat family
   set_fact: keystone_service="openstack-keystone"
+  when: ansible_os_family == 'RedHat'
+
+- name: Set service facts for RedHat family
+  set_fact: webserver_service="httpd"
   when: ansible_os_family == 'RedHat'

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -18,18 +18,22 @@
 #
 
 
-- name: Set service facts for Debian family
-  set_fact: keystone_service="keystone"
+- name: Set facts for Debian family
   when: ansible_os_family == 'Debian'
+  set_fact:
+    keystone_service="keystone"
+    webserver_service="apache2"
+    webserver_conf_path=/etc/apache2/apache2.conf
+    webserver_new_conf_dir_path="/etc/apache2/sites-available"
+    memcached_service="memcache"
 
-- name: Set service facts for Debian family
-  set_fact: webserver_service="apache2"
-  when: ansible_os_family == 'Debian'
 
-- name: Set service facts for RedHat family
-  set_fact: keystone_service="openstack-keystone"
+- name: Set facts for RedHat family
   when: ansible_os_family == 'RedHat'
+  set_fact:
+    keystone_service="openstack-keystone"
+    webserver_service="httpd"
+    webserver_conf_path="/etc/httpd/conf/httpd.conf"
+    webserver_new_conf_dir_path="/etc/httpd/conf.d"
+    memcached_service="memcached.service"
 
-- name: Set service facts for RedHat family
-  set_fact: webserver_service="httpd"
-  when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,3 +39,4 @@
 - include: roles.yml
 - include: cleanup.yml
 - include: sanitycheck.yml
+  when: keystone_run_sanity_check

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,3 +38,4 @@
 - include: users.yml
 - include: roles.yml
 - include: cleanup.yml
+- include: sanitycheck.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
 - include: facts.yml
 - include: packages.yml
 - include: configuration.yml
+- include: wsgi.yml
 
 - meta: flush_handlers
 
@@ -35,7 +36,6 @@
 
 - include: maintenance.yml
 
-- include: wsgi.yml
 - include: endpoints.yml
 - include: tenants.yml
 - include: users.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,10 @@
     host={{ keystone_hostname }}
     port={{ keystone_admin_port }}
 
+- include: maintenance.yml
+
 - include: wsgi.yml
 - include: endpoints.yml
 - include: tenants.yml
 - include: users.yml
 - include: roles.yml
-- include: maintenance.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
 
 - include: maintenance.yml
 
+- include: wsgi.yml
 - include: endpoints.yml
 - include: tenants.yml
 - include: users.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,15 +27,12 @@
 
 - meta: flush_handlers
 
-- name: Make sure Keystone is started
-  service: name={{ keystone_service }} state=started
-- name: Wait Keystone admin serice
-  wait_for: >
-    host={{ keystone_hostname }}
-    port={{ keystone_admin_port }}
+- name: Ensure that the Keystone service is stopped
+  service:
+    name={{ keystone_service }}
+    state=stopped
 
 - include: maintenance.yml
-
 - include: endpoints.yml
 - include: tenants.yml
 - include: users.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,10 +33,9 @@
     host={{ keystone_hostname }}
     port={{ keystone_admin_port }}
 
-- include: maintenance.yml
-
 - include: wsgi.yml
 - include: endpoints.yml
 - include: tenants.yml
 - include: users.yml
 - include: roles.yml
+- include: maintenance.yml

--- a/tasks/maintenance.yml
+++ b/tasks/maintenance.yml
@@ -18,15 +18,6 @@
 # limitations under the License.
 #
 
-- name: Add a cronjob to remove Keystone expired token
-  cron: >
-    name="Remove keystone expired token"
-    minute=0
-    hour=*/1
-    user=keystone
-    job="keystone-manage token_flush > {{ keystone_log_dir }}/keystone-tokenflush.log 2>&1"
-    cron_file="remove-keystone-expired-tokens"
-
 - name: MAINT Remove the default keystone sqlite database
   file:
     path=/var/lib/keystone/keystone.db

--- a/tasks/maintenance.yml
+++ b/tasks/maintenance.yml
@@ -19,6 +19,7 @@
 #
 
 - name: MAINT Remove the default keystone sqlite database
+  when: keystone_remove_sqlite_db
   file:
     path=/var/lib/keystone/keystone.db
     state=absent

--- a/tasks/maintenance.yml
+++ b/tasks/maintenance.yml
@@ -26,3 +26,8 @@
     user=keystone
     job="keystone-manage token_flush > {{ keystone_log_dir }}/keystone-tokenflush.log 2>&1"
     cron_file="remove-keystone-expired-tokens"
+
+- name: MAINT Remove the default keystone sqlite database
+  file:
+    path=/var/lib/keystone/keystone.db
+    state=absent

--- a/tasks/maintenance.yml
+++ b/tasks/maintenance.yml
@@ -31,3 +31,9 @@
   file:
     path=/var/lib/keystone/keystone.db
     state=absent
+
+- name: MAIN Remove the temporary auth token mechanism
+  lineinfile:
+    dest=/etc/keystone/keystone-paste.ini
+    regexp=' admin_token_auth '
+    state=absent

--- a/tasks/maintenance.yml
+++ b/tasks/maintenance.yml
@@ -31,9 +31,3 @@
   file:
     path=/var/lib/keystone/keystone.db
     state=absent
-
-- name: MAIN Remove the temporary auth token mechanism
-  lineinfile:
-    dest=/etc/keystone/keystone-paste.ini
-    regexp=' admin_token_auth '
-    state=absent

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -22,4 +22,9 @@
   with_items:
     - keystone
     - python-keystoneclient
+    - apache2
+    - libapache2-mod-wsgi
+    - memcached
+    - python-memcache
+
 

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -24,6 +24,7 @@
   apt: name="{{ item }}" state=present
   with_items:
     - keystone
+    - python-openstackclient
     - python-keystoneclient
     - apache2
     - libapache2-mod-wsgi

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -17,7 +17,10 @@
 # limitations under the License.
 #
 
-- name: Install keystone service and client
+- name: Disable keystone service from starting automatically
+  lineinfile: dest=/etc/init/keystone.override create=yes line="manual"
+
+- name: Install keystone-related packages
   apt: name="{{ item }}" state=present
   with_items:
     - keystone
@@ -26,5 +29,4 @@
     - libapache2-mod-wsgi
     - memcached
     - python-memcache
-
-
+    - python-mysqldb

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -32,3 +32,7 @@
   notify:
     - Enable Memcached
     - Start Memcached
+    - Enable Apache
+    - Start Apache
+
+- meta: flush_handlers

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -18,9 +18,16 @@
 #
 
 
-- name: Install keystone service and client
+- name: Install Applications (yum)
   yum: name="{{ item }}" state=present
   with_items:
     - openstack-keystone
-    - python-keystoneclient
-
+    - httpd
+    - mod_wsgi
+    - python-openstackclient
+    - memcached
+    - python-memcached
+    - MySQL-python
+  notify:
+    - Enable Memcached
+    - Start Memcached

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -28,6 +28,7 @@
     - memcached
     - python-memcached
     - MySQL-python
+    - openstack-selinux
   notify:
     - Enable Memcached
     - Start Memcached

--- a/tasks/roles.yml
+++ b/tasks/roles.yml
@@ -23,7 +23,7 @@
     role="{{ item.name }}"
     user="{{ item.user }}"
     tenant="{{ item.tenant }}"
-    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/v2.0"
+    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/{{ keystone_api_version }}"
     token="{{ keystone_admin_token }}"
     state="{{ item.state|default('present') }}"
   register: result

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -1,0 +1,81 @@
+---
+
+#
+# Copyright (c) 2015 Badi' Abdul-Wahid <abdulwahidc@gmail.com>
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- name: SANITY CHECK Request auth token as admin
+  shell: >-
+    openstack
+    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-project-name admin
+    --os-username admin
+    --os-auth-type password
+    --os-password {{ keystone_admin_password }}
+    token issue
+  register: token_test
+- debug: var=token_test.stdout_lines
+
+- name: SANITY CHECK Try with domain
+  shell: >-
+    openstack
+    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-project-domain-id default
+    --os-user-domain-id default
+    --os-project-name admin
+    --os-username admin
+    --os-auth-type password
+    --os-password {{ keystone_admin_password }}
+    token issue
+  register: domain_test
+- debug: var=domain_test.stdout_lines
+
+- name: SANITY CHECK Admin user has correct privileges
+  shell: >-
+    openstack
+    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-project-name admin
+    --os-username admin
+    --os-auth-type password
+    --os-password {{ keystone_admin_password }}
+    project list
+  register: admin_test
+- debug: var=admin_test.stdout_lines
+
+- name: SANITY CHECK List users
+  shell: >-
+    openstack
+    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-project-name admin
+    --os-username admin
+    --os-auth-type password
+    --os-password {{ keystone_admin_password }}
+    user list
+  register: userlist_test
+- debug: var=userlist_test.stdout_lines
+
+- name: SANITY CHECK List roles
+  shell: >-
+    openstack
+    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-project-name admin
+    --os-username admin
+    --os-auth-type password
+    --os-password {{ keystone_admin_password }}
+    role list
+  register: rolelist_test
+- debug: var=rolelist_test.stdout_lines

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -28,6 +28,7 @@
     --os-password "{{ keystone_admin_password }}"
     token issue
   register: token_test
+  changed_when: token_test.rc != 0
 - debug: var=token_test.stdout_lines
 
 - name: SANITY CHECK Try with domain
@@ -42,6 +43,7 @@
     --os-password "{{ keystone_admin_password }}"
     token issue
   register: domain_test
+  changed_when: domain_test.rc != 0
 - debug: var=domain_test.stdout_lines
 
 - name: SANITY CHECK Admin user has correct privileges
@@ -54,6 +56,7 @@
     --os-password "{{ keystone_admin_password }}"
     project list
   register: admin_test
+  changed_when: admin_test.rc != 0
 - debug: var=admin_test.stdout_lines
 
 - name: SANITY CHECK List users
@@ -66,6 +69,7 @@
     --os-password "{{ keystone_admin_password }}"
     user list
   register: userlist_test
+  changed_when: userlist_test.rc != 0
 - debug: var=userlist_test.stdout_lines
 
 - name: SANITY CHECK List roles
@@ -78,4 +82,5 @@
     --os-password "{{ keystone_admin_password }}"
     role list
   register: rolelist_test
+  changed_when: rolelist_test.rc != 0
 - debug: var=rolelist_test.stdout_lines

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -25,7 +25,7 @@
     --os-project-name admin
     --os-username admin
     --os-auth-type password
-    --os-password {{ keystone_admin_password }}
+    --os-password "{{ keystone_admin_password }}"
     token issue
   register: token_test
 - debug: var=token_test.stdout_lines
@@ -39,7 +39,7 @@
     --os-project-name admin
     --os-username admin
     --os-auth-type password
-    --os-password {{ keystone_admin_password }}
+    --os-password "{{ keystone_admin_password }}"
     token issue
   register: domain_test
 - debug: var=domain_test.stdout_lines
@@ -51,7 +51,7 @@
     --os-project-name admin
     --os-username admin
     --os-auth-type password
-    --os-password {{ keystone_admin_password }}
+    --os-password "{{ keystone_admin_password }}"
     project list
   register: admin_test
 - debug: var=admin_test.stdout_lines
@@ -63,7 +63,7 @@
     --os-project-name admin
     --os-username admin
     --os-auth-type password
-    --os-password {{ keystone_admin_password }}
+    --os-password "{{ keystone_admin_password }}"
     user list
   register: userlist_test
 - debug: var=userlist_test.stdout_lines
@@ -75,7 +75,7 @@
     --os-project-name admin
     --os-username admin
     --os-auth-type password
-    --os-password {{ keystone_admin_password }}
+    --os-password "{{ keystone_admin_password }}"
     role list
   register: rolelist_test
 - debug: var=rolelist_test.stdout_lines

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -21,7 +21,7 @@
 - name: SANITY CHECK Request auth token as admin
   shell: >-
     openstack
-    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-auth-url http://{{ keystone_admin_bind_host }}:35357
     --os-project-name admin
     --os-username admin
     --os-auth-type password
@@ -34,7 +34,7 @@
 - name: SANITY CHECK Try with domain
   shell: >-
     openstack
-    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-auth-url http://{{ keystone_admin_bind_host }}:35357
     --os-project-domain-id default
     --os-user-domain-id default
     --os-project-name admin
@@ -49,7 +49,7 @@
 - name: SANITY CHECK Admin user has correct privileges
   shell: >-
     openstack
-    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-auth-url http://{{ keystone_admin_bind_host }}:35357
     --os-project-name admin
     --os-username admin
     --os-auth-type password
@@ -62,7 +62,7 @@
 - name: SANITY CHECK List users
   shell: >-
     openstack
-    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-auth-url http://{{ keystone_admin_bind_host }}:35357
     --os-project-name admin
     --os-username admin
     --os-auth-type password
@@ -75,7 +75,7 @@
 - name: SANITY CHECK List roles
   shell: >-
     openstack
-    --os-auth-url http://{{ ansible_hostname }}:35357
+    --os-auth-url http://{{ keystone_admin_bind_host }}:35357
     --os-project-name admin
     --os-username admin
     --os-auth-type password

--- a/tasks/tenants.yml
+++ b/tasks/tenants.yml
@@ -22,7 +22,7 @@
   keystone_user: >
     tenant="{{ item.name }}"
     tenant_description="{{ item.description|default('') }}"
-    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/v2.0"
+    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/{{ keystone_api_version }}"
     token="{{ keystone_admin_token }}"
     state="{{ item.state|default('present') }}"
   register: result

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -24,7 +24,7 @@
     password="{{ item.password }}"
     tenant="{{ item.tenant }}"
     email="{{ item.email|default('nobody@localhost') }}"
-    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/v2.0"
+    endpoint="{{ keystone_protocol }}://{{ keystone_hostname }}:{{ keystone_admin_port }}/{{ keystone_api_version }}"
     token="{{ keystone_admin_token }}"
     state="{{ item.state|default('present') }}"
   with_items: keystone_users

--- a/tasks/wsgi.yml
+++ b/tasks/wsgi.yml
@@ -40,12 +40,21 @@
     recurse=yes
 
 
-- name: WSGI Restart webserver
+# the particular ordering below is critical.  keystone must be started
+# AFTER apache is reloaded in order to use WSGI
+
+
+- name: WSGI Stop keystone
   service:
-    name={{ webserver_service }}
+    name={{ keystone_service }}
     state=stopped
 
 - name: WSGI Restart webserver
   service:
     name={{ webserver_service }}
+    state=started
+
+- name: WSGI Start keystone
+  service:
+    name={{ keystone_service }}
     state=started

--- a/tasks/wsgi.yml
+++ b/tasks/wsgi.yml
@@ -4,15 +4,16 @@
 
 - name: WSGI Tell apache to use the hostname as the servername
   lineinfile:
-    dest=/etc/apache2/apache2.conf
+    dest={{ webserver_conf_path }}
     line="ServerName {{ keystone_hostname }}"
 
 - name: WSGI Create the WSGI Keystone configuration file
   template:
     src=wsgi-keystone.conf
-    dest=/etc/apache2/sites-available/wsgi-keystone.conf
+    dest={{ webserver_new_conf_dir_path }}/wsgi-keystone.conf
 
 - name: WSGI Enable the identity service virtual hosts
+  when: ansible_os_family == "Debian"
   file:
     src=/etc/apache2/sites-available/{{ item.name }}
     dest=/etc/apache2/sites-enabled/{{ item.name }}

--- a/tasks/wsgi.yml
+++ b/tasks/wsgi.yml
@@ -5,7 +5,7 @@
 - name: WSGI Tell apache to use the hostname as the servername
   lineinfile:
     dest=/etc/apache2/apache2.conf
-    line="ServerName {{ ansible_hostname }}"
+    line="ServerName {{ keystone_hostname }}"
 
 - name: WSGI Create the WSGI Keystone configuration file
   template:
@@ -24,20 +24,20 @@
 
 - name: WSGI Setup directory structure
   file:
-    path={{ keystone.cgibin.dir }}
+    path={{ keystone_cgibin_dir }}
     state=directory
 
 - name: WSGI copy the components from the upstream repository
   get_url:
-    url="{{ keystone.cgibin.upstream_wsgi_components }}"
-    dest={{ keystone.cgibin.dir }}/{{ item }}
+    url="{{ keystone_upstream_wsgi_components }}"
+    dest={{ keystone_cgibin_dir }}/{{ item }}
   with_items:
-    - main
-    - admin
+    - "{{ keystone_wsgi_main_name }}"
+    - "{{ keystone_wsgi_admin_name }}"
 
 - name: WSGI Fix ownership and permissions
   file:
-    path={{ keystone.cgibin.dir }}
+    path={{ keystone_cgibin_dir }}
     owner=keystone
     group=keystone
     mode=0755

--- a/tasks/wsgi.yml
+++ b/tasks/wsgi.yml
@@ -1,5 +1,7 @@
 ---
 
+- meta: flush_handlers
+
 - name: WSGI Tell apache to use the hostname as the servername
   lineinfile:
     dest=/etc/apache2/apache2.conf
@@ -17,6 +19,8 @@
     state=link
   with_items:
     - name: wsgi-keystone.conf
+  notify:
+    - Use WSGI
 
 - name: WSGI Setup directory structure
   file:
@@ -38,23 +42,4 @@
     group=keystone
     mode=0755
     recurse=yes
-
-
-# the particular ordering below is critical.  keystone must be started
-# AFTER apache is reloaded in order to use WSGI
-
-
-- name: WSGI Stop keystone
-  service:
-    name={{ keystone_service }}
-    state=stopped
-
-- name: WSGI Restart webserver
-  service:
-    name={{ webserver_service }}
-    state=started
-
-- name: WSGI Start keystone
-  service:
-    name={{ keystone_service }}
-    state=started
+    

--- a/tasks/wsgi.yml
+++ b/tasks/wsgi.yml
@@ -1,0 +1,51 @@
+---
+
+- name: WSGI Tell apache to use the hostname as the servername
+  lineinfile:
+    dest=/etc/apache2/apache2.conf
+    line="ServerName {{ ansible_hostname }}"
+
+- name: WSGI Create the WSGI Keystone configuration file
+  template:
+    src=wsgi-keystone.conf
+    dest=/etc/apache2/sites-available/wsgi-keystone.conf
+
+- name: WSGI Enable the identity service virtual hosts
+  file:
+    src=/etc/apache2/sites-available/{{ item.name }}
+    dest=/etc/apache2/sites-enabled/{{ item.name }}
+    state=link
+  with_items:
+    - name: wsgi-keystone.conf
+
+- name: WSGI Setup directory structure
+  file:
+    path={{ keystone.cgibin.dir }}
+    state=directory
+
+- name: WSGI copy the components from the upstream repository
+  get_url:
+    url="{{ keystone.cgibin.upstream_wsgi_components }}"
+    dest={{ keystone.cgibin.dir }}/{{ item }}
+  with_items:
+    - main
+    - admin
+
+- name: WSGI Fix ownership and permissions
+  file:
+    path={{ keystone.cgibin.dir }}
+    owner=keystone
+    group=keystone
+    mode=0755
+    recurse=yes
+
+
+- name: WSGI Restart webserver
+  service:
+    name={{ webserver_service }}
+    state=stopped
+
+- name: WSGI Restart webserver
+  service:
+    name={{ webserver_service }}
+    state=started

--- a/templates/wsgi-keystone.conf
+++ b/templates/wsgi-keystone.conf
@@ -4,7 +4,7 @@ Listen 35357
 <VirtualHost *:5000>
     WSGIDaemonProcess keystone-public processes=5 threads=1 user=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-public
-    WSGIScriptAlias / {{ keystone.cgibin.dir }}/{{ keystone.cgibin.main_name }}
+    WSGIScriptAlias / {{ keystone_cgibin_dir }}/{{ keystone_wsgi_main_name }}
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
     <IfVersion >= 2.4>
@@ -18,7 +18,7 @@ Listen 35357
 <VirtualHost *:35357>
     WSGIDaemonProcess keystone-admin processes=5 threads=1 user=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-admin
-    WSGIScriptAlias / {{ keystone.cgibin.dir }}/{{ keystone.cgibin.admin_name }}
+    WSGIScriptAlias / {{ keystone_cgibin_dir }}/{{ keystone_wsgi_admin_name }}
     WSGIApplicationGroup %{GLOBAL}
     WSGIPassAuthorization On
     <IfVersion >= 2.4>

--- a/templates/wsgi-keystone.conf
+++ b/templates/wsgi-keystone.conf
@@ -11,8 +11,8 @@ Listen {{ keystone_admin_port }}
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
     LogLevel info
-    ErrorLog /var/log/apache2/keystone-error.log
-    CustomLog /var/log/apache2/keystone-access.log combined
+    ErrorLog /var/log/{{ webserver_service }}/keystone-error.log
+    CustomLog /var/log/{{ webserver_service }}/keystone-access.log combined
 </VirtualHost>
 
 <VirtualHost {{ keystone_admin_bind_host }}:{{ keystone_admin_port }}>
@@ -25,6 +25,6 @@ Listen {{ keystone_admin_port }}
       ErrorLogFormat "%{cu}t %M"
     </IfVersion>
     LogLevel info
-    ErrorLog /var/log/apache2/keystone-error.log
-    CustomLog /var/log/apache2/keystone-access.log combined
+    ErrorLog /var/log/{{ webserver_service }}/keystone-error.log
+    CustomLog /var/log/{{ webserver_service }}/keystone-access.log combined
 </VirtualHost>

--- a/templates/wsgi-keystone.conf
+++ b/templates/wsgi-keystone.conf
@@ -1,0 +1,30 @@
+Listen 5000
+Listen 35357
+
+<VirtualHost *:5000>
+    WSGIDaemonProcess keystone-public processes=5 threads=1 user=keystone display-name=%{GROUP}
+    WSGIProcessGroup keystone-public
+    WSGIScriptAlias / {{ keystone.cgibin.dir }}/{{ keystone.cgibin.main_name }}
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIPassAuthorization On
+    <IfVersion >= 2.4>
+      ErrorLogFormat "%{cu}t %M"
+    </IfVersion>
+    LogLevel info
+    ErrorLog /var/log/apache2/keystone-error.log
+    CustomLog /var/log/apache2/keystone-access.log combined
+</VirtualHost>
+
+<VirtualHost *:35357>
+    WSGIDaemonProcess keystone-admin processes=5 threads=1 user=keystone display-name=%{GROUP}
+    WSGIProcessGroup keystone-admin
+    WSGIScriptAlias / {{ keystone.cgibin.dir }}/{{ keystone.cgibin.admin_name }}
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIPassAuthorization On
+    <IfVersion >= 2.4>
+      ErrorLogFormat "%{cu}t %M"
+    </IfVersion>
+    LogLevel info
+    ErrorLog /var/log/apache2/keystone-error.log
+    CustomLog /var/log/apache2/keystone-access.log combined
+</VirtualHost>

--- a/templates/wsgi-keystone.conf
+++ b/templates/wsgi-keystone.conf
@@ -1,7 +1,7 @@
-Listen 5000
-Listen 35357
+Listen {{ keystone_port }}
+Listen {{ keystone_admin_port }}
 
-<VirtualHost *:5000>
+<VirtualHost {{ keystone_bind_host }}:{{ keystone_port }}>
     WSGIDaemonProcess keystone-public processes=5 threads=1 user=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / {{ keystone_cgibin_dir }}/{{ keystone_wsgi_main_name }}
@@ -15,7 +15,7 @@ Listen 35357
     CustomLog /var/log/apache2/keystone-access.log combined
 </VirtualHost>
 
-<VirtualHost *:35357>
+<VirtualHost {{ keystone_admin_bind_host }}:{{ keystone_admin_port }}>
     WSGIDaemonProcess keystone-admin processes=5 threads=1 user=keystone display-name=%{GROUP}
     WSGIProcessGroup keystone-admin
     WSGIScriptAlias / {{ keystone_cgibin_dir }}/{{ keystone_wsgi_admin_name }}

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,0 +1,51 @@
+# -*- mode: ruby -*-
+
+PROVIDER = "libvirt"
+INVENTORY_PATH = 'inventory'
+
+######################################################################
+
+def inventory_line(ip, name, provider="libvirt")
+     "#{name} ansible_ssh_host=#{ip} ansible_ssh_private_key_file=.vagrant/machines/#{name}/#{provider}/private_key\n"
+end
+
+def start(config, box, name, ip, netmask = "255.255.255.0")
+  config.vm.define name do |node|
+    node.vm.box = box
+    node.vm.hostname = name
+    node.vm.network :private_network, :ip => ip, :netmask => netmask
+  end
+
+  config.vm.provision :shell,
+                      inline: "test -d /root/.ssh || cp -r /home/vagrant/.ssh /root"
+
+  File.open(INVENTORY_PATH, 'a') do |fd|
+    fd << inventory_line(ip, name, provier=PROVIDER)
+  end
+
+end
+
+def set_hardware(config, provider)
+  config.vm.provider provider do |machine|
+    machine.memory = 1024
+    machine.cpus = 1
+  end
+end
+
+
+######################################################################
+
+
+File.open(INVENTORY_PATH, 'w') do |fd|
+end
+
+Vagrant.configure(2) do |config|
+  set_hardware config, :libvirt
+  set_hardware config, :virtualbox
+
+  start config, "baremettle/ubuntu-14.04", "ubuntu", "192.168.1.100"
+  start config, "centos/7",                "centos", "192.168.1.101"
+
+end
+
+

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+host_key_checking = False
+roles_path = ../../

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,2 @@
-localhost
+ubuntu ansible_ssh_host=192.168.1.100 ansible_ssh_private_key_file=.vagrant/machines/ubuntu/libvirt/private_key
+centos ansible_ssh_host=192.168.1.101 ansible_ssh_private_key_file=.vagrant/machines/centos/libvirt/private_key

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: localhost
+- hosts: all
   remote_user: root
   pre_tasks:
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,7 +4,9 @@
   remote_user: root
   roles:
     - role: openstack-keystone
+      keystone_run_sanity_check: yes
       keystone_admin_token: "os token"
+      keystone_admin_password: "admin password"
       keystone_admin_bind_host: 127.0.0.1
       keystone_bind_host: 127.0.0.1
       keystone_tenants:
@@ -12,7 +14,7 @@
         - { name: service, description: "Service tenant" }
         - { name: demo, description: "Demo tenant"  }
       keystone_users:
-        - { name: admin, password: "admin password", tenant: admin }
+        - { name: admin, password: "{{ keystone_admin_password }}", tenant: admin }
         - { name: demo, password: "demo password", tenant: demo }
         - { name: glance, password: "glance password", tenant: service }
       keystone_roles:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -28,8 +28,8 @@
       keystone_run_sanity_check: yes
       keystone_admin_token: "os token"
       keystone_admin_password: "admin password"
-      keystone_admin_bind_host: 127.0.0.1
-      keystone_bind_host: 127.0.0.1
+      keystone_admin_bind_host: localhost
+      keystone_bind_host: localhost
       keystone_tenants:
         - { name: admin, description: "Admin tenant" }
         - { name: service, description: "Service tenant" }
@@ -47,6 +47,6 @@
         - { name: glance, service_type: image }
       keystone_endpoints:
         - service_name: keystone
-          public_url: "http://127.0.0.1:5000/v2.0"
-          internal_url: "http://127.0.0.1:5000/v2.0"
-          admin_url: "http://127.0.0.1:35357/v2.0"
+          public_url: "http://localhost:5000/v2.0"
+          internal_url: "http://localhost:5000/v2.0"
+          admin_url: "http://localhost:35357/v2.0"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,6 +2,27 @@
 
 - hosts: localhost
   remote_user: root
+  pre_tasks:
+
+    - name: Install Ubuntu Cloud archive keyring (Debian)
+      when: ansible_os_family == 'Debian'
+      apt: pkg=ubuntu-cloud-keyring
+
+    - name: Enable OpenStack (Debian)
+      when: ansible_os_family == 'Debian'
+      apt_repository: repo='deb http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/kilo main'
+                      state=present
+                      update_cache=yes
+
+    - name: Enable OpenStack (RedHat)
+      when: ansible_os_family == 'RedHat'
+      yum: name="{{ item }}"
+           state=present
+           update_cache=yes
+      with_items:
+        - "http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm"
+        - "http://rdo.fedorapeople.org/openstack-kilo/rdo-release-kilo.rpm"
+
   roles:
     - role: openstack-keystone
       keystone_run_sanity_check: yes


### PR DESCRIPTION
Allow deployment of the Kilo version of Keystone onto Ubuntu 14.04
# Summary of changes:
- use memcached for tokens
- the `keystone` service is disabled. Access is done using WSGI via Apache's `mod_wsgi`
- disabling token-based authentication for the admin user upon completion
- a set of "sanity check" tasks which are run if `keystone_run_sanity_check` variable is set to `yes`
- the default region is switched to `RegionOne` instead of `regionOne`
# Testing

Kilo does not support Ubuntu 12.04, which is the only option for on Travis CI (to my knowledge).
Since the travis builds will fail, Vagrant is used to set up Ubuntu 14.04 and CentOS 7 libvirt instances to test deployment.
Currently, the Ubuntu test succeeds but the CentOS test fails, which I don't have time to fully dig into right now.
