### PR TITLE
Correct metadata dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,6 @@ galaxy_info:
   min_ansible_version: 1.7
   categories:
     - cloud
-  dependencies: []
   platforms:
     - name: Ubuntu
       versions:
@@ -20,4 +19,4 @@ galaxy_info:
       versions:
         - 6
         - 7
-
+dependencies: []


### PR DESCRIPTION
Role fails to install via ansible-galaxy due to incorrect nesting of the
`dependencies` key.

```
$ ansible-galaxy install -r requirements.yml

- openstack-ansible-galaxy.openstack-keystone was installed successfully
Traceback (most recent call last):
  File "/Users/jodewey/.homebrew/bin/ansible-galaxy", line 959, in <module>
    main()
  File "/Users/jodewey/.homebrew/bin/ansible-galaxy", line 953, in main
    fn(args, options, parser)
  File "/Users/jodewey/.homebrew/bin/ansible-galaxy", line 845, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies'
```
