### PR TITLE
Flag to enable/disable bootstrap

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,3 +41,4 @@ keystone_database_url: sqlite:////var/lib/keystone/keystone.db
 # Misc
 keystone_api_retries: 3
 keystone_api_retries_delay: 5
+keystone_boostrap: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,10 @@
 - include: maintenance.yml
 
 - include: endpoints.yml
+  when: keystone_boostrap
 - include: tenants.yml
+  when: keystone_boostrap
 - include: users.yml
+  when: keystone_boostrap
 - include: roles.yml
+  when: keystone_boostrap


### PR DESCRIPTION
Under certain scenarios (#6) we may not want every keystone node
to provision tenants, users, endpoints, and roles simultaneously.

This patch allows us to enable/disable the bootstrapping of keystone.
