### PR TITLE
Only run db sync on bootstrap node

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,4 +41,4 @@ keystone_database_url: sqlite:////var/lib/keystone/keystone.db
 # Misc
 keystone_api_retries: 3
 keystone_api_retries_delay: 5
-keystone_boostrap: true
+keystone_bootstrap: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -33,3 +33,4 @@
   sudo_user: keystone
   notify:
     - Restart Keystone
+  when: keystone_boostrap

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -33,4 +33,4 @@
   sudo_user: keystone
   notify:
     - Restart Keystone
-  when: keystone_boostrap
+  when: keystone_bootstrap

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,10 +36,10 @@
 - include: maintenance.yml
 
 - include: endpoints.yml
-  when: keystone_boostrap
+  when: keystone_bootstrap
 - include: tenants.yml
-  when: keystone_boostrap
+  when: keystone_bootstrap
 - include: users.yml
-  when: keystone_boostrap
+  when: keystone_bootstrap
 - include: roles.yml
-  when: keystone_boostrap
+  when: keystone_bootstrap


### PR DESCRIPTION
We run into contention when multiple systems converge and run
simultaneous db syncs.
