### PR TITLE
Fix Idempotency Issue with CentOS

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -29,7 +29,9 @@
 
     # Workaround for selinux errors when using sqlite DB
     - name: Set permissive SElinux for httpd domain
-      command: semanage permissive -a httpd_t
+      selinux_permissive:
+        name: 'httpd_t'
+        permissive: True
       when:
         - ansible_os_family == 'RedHat'
         - ansible_selinux.mode is defined


### PR DESCRIPTION
Fix idempotency issue with CentOS, by using `selinux_permissive` module
instead of `command` module.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
