### PR TITLE
Remove Service Workaround for Docker

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -23,6 +23,12 @@
 - include: packages_redhat.yml
   when: ansible_os_family == 'RedHat'
 
+- name: Stop and disable keystone
+  service:
+    enabled: False
+    name: '{{ keystone_service }}'
+    state: stopped
+
 - name: Start and enable memcached
   service:
     enabled: True

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -32,9 +32,3 @@
     - 'openstack-selinux'
     - 'python-memcached'
     - 'python-openstackclient'
-
-- name: Stop and disable keystone
-  service:
-    enabled: False
-    name: '{{ keystone_service }}'
-    state: stopped

--- a/tasks/packages_ubuntu.yml
+++ b/tasks/packages_ubuntu.yml
@@ -17,22 +17,6 @@
 # limitations under the License.
 #
 
-- name: Disable keystone service from starting automatically (upstart)
-  lineinfile:
-    dest: '/etc/init/keystone.override'
-    create: True
-    line: 'manual'
-  when:
-    ansible_distribution_release == 'trusty'
-
-- name: Disable keystone service from starting automatically (systemd)
-  file:
-    dest: '/etc/systemd/system/keystone.service'
-    src: '/dev/null'
-    state: link
-  when:
-    ansible_distribution_release == 'xenial'
-
 - name: Install keystone-related packages
   apt:
     name: '{{ item }}'


### PR DESCRIPTION
Now that we removed Docker from Travis CI, we can go ahead and remove
the service stop workaround (stopping services without using
`systemctl`) and implement stopping services in a proper way.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
