### PR TITLE
Refine Notify Timing

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -79,6 +79,8 @@
   command: 'keystone-manage db_sync {{ keystone_database_schema_version }}'
   become: True
   become_user: 'keystone'
+  notify:
+    - Restart webserver
   when: keystone_manage_db_version|changed
 
 - name: Create fernet keys

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -21,8 +21,6 @@
   yum:
     name: '{{ item }}'
     state: present
-  notify:
-    - Restart webserver
   with_items:
     - 'MySQL-python'
     - 'httpd'

--- a/tasks/packages_ubuntu.yml
+++ b/tasks/packages_ubuntu.yml
@@ -37,8 +37,6 @@
   apt:
     name: '{{ item }}'
     state: present
-  notify:
-    - Restart webserver
   with_items:
     - 'apache2'
     - 'keystone'


### PR DESCRIPTION
Since we don't upgrade packages, there are no feasible scenario that
requires restarting webserver when installing packages (restart in
normal usage is covered by `configuration.yml`).  However, we might need
to restart webserver if the database is upgraded (which might occur when
someone had a running environment and upgraded the package manually but
didn't run the migration).

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
