### PR TITLE
Dynamic Database Migration Version Detection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,6 @@ openstack_keystone_default_region: 'RegionOne'
 
 # Database
 openstack_keystone_database_url: 'sqlite:////var/lib/keystone/keystone.db'
-openstack_keystone_database_schema_version: 96
 openstack_keystone_remove_sqlite_db: False
 
 # Memcached

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -70,16 +70,26 @@
       option: 'caching'
       value: '{{ openstack_keystone_token_caching|default(True) }}'
 
+- name: Get latest keystone database version
+  shell: >-
+    ls {{ openstack_keystone_database_migration_repository }}
+    | grep '^[0-9]\{3\}_' | sort -n | tail -n 1 | awk -F '_' '{ print $1; }'
+  always_run: True
+  changed_when: False
+  register: openstack_keystone_database_schema_version
+
 - name: Get current keystone database version
   command: 'keystone-manage db_version'
   always_run: True
   become: True
   become_user: 'keystone'
-  changed_when: openstack_keystone_manage_db_version.stdout|int != openstack_keystone_database_schema_version
+  changed_when: >-
+    openstack_keystone_manage_db_version.stdout|int
+    != openstack_keystone_database_schema_version.stdout|int
   register: openstack_keystone_manage_db_version
 
 - name: Migrate keystone database to desired version
-  command: 'keystone-manage db_sync {{ openstack_keystone_database_schema_version }}'
+  command: 'keystone-manage db_sync {{ openstack_keystone_database_schema_version.stdout }}'
   become: True
   become_user: 'keystone'
   notify:

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -24,6 +24,8 @@
     openstack_keystone_webserver_conf_path: '/etc/apache2/apache2.conf'
     openstack_keystone_webserver_new_conf_dir_path: '/etc/apache2/sites-available'
     openstack_keystone_memcached_service: 'memcached'
+    openstack_keystone_database_migration_repository: >-
+      '/usr/lib/python2.7/dist-packages/keystone/common/sql/migrate_repo/versions'
   when: ansible_os_family == 'Debian'
 
 - name: Set facts for RedHat family
@@ -33,4 +35,6 @@
     openstack_keystone_webserver_conf_path: '/etc/httpd/conf/httpd.conf'
     openstack_keystone_webserver_new_conf_dir_path: '/etc/httpd/conf.d'
     openstack_keystone_memcached_service: 'memcached.service'
+    openstack_keystone_database_migration_repository: >-
+      '/usr/lib/python2.7/site-packages/keystone/common/sql/migrate_repo/versions'
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
Dynamically detect the latest database migration version, instead of
hardcoding the latest database migration version, which is difficult to
keep up with the upstream changes.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
