### PR TITLE
Fix Ansible 2.2 Incompatibility

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,48 +5,57 @@
 - hosts: all
   become: True
 
-  roles:
-    - role: mysql
-      mysql_root_password: 'mysqlpassword'
-      mysql_bind_address: 0.0.0.0
-      mysql_innodb_file_per_table: 'innodb_file_per_table'
-      mysql_packages:
-        - mariadb-client
-        - mariadb-server
-        - python-mysqldb
-      mysql_databases:
-        - name: 'keystone'
-      mysql_users:
-        - name: 'keystone'
-          password: 'keystonepassword'
-          priv: 'keystone.*:ALL'
-          host: '%'
-        - name: 'keystone'
-          password: 'keystonepassword'
-          priv: 'keystone.*:ALL'
-          host: 'localhost'
+  pre_tasks:
+    - name: Set facts for mysql role on Debian based system
+      set_fact:
+        mysql_root_password: 'mysqlpassword'
+        mysql_bind_address: '0.0.0.0'
+        mysql_innodb_file_per_table: 'innodb_file_per_table'
+        mysql_daemon: 'mysql'
+        mysql_log_error: '/var/log/mysql/error.log'
+        mysql_pid_file: '/var/run/mysqld/mysqld.pid'
+        mysql_packages:
+          - 'mariadb-client'
+          - 'mariadb-server'
+          - 'python-mysqldb'
+        mysql_databases:
+          - name: 'keystone'
+        mysql_users:
+          - name: 'keystone'
+            password: 'keystonepassword'
+            priv: 'keystone.*:ALL'
+            host: '%'
+          - name: 'keystone'
+            password: 'keystonepassword'
+            priv: 'keystone.*:ALL'
+            host: 'localhost'
       when: ansible_os_family == 'Debian'
 
-    - role: mysql
-      mysql_root_password: 'mysqlpassword'
-      mysql_bind_address: 0.0.0.0
-      mysql_innodb_file_per_table: 'innodb_file_per_table'
-      mysql_daemon: 'mariadb'
-      mysql_log_error: '/var/log/mariadb/mariadb.log'
-      mysql_syslog_tag: 'mariadb'
-      mysql_pid_file: '/var/run/mariadb/mariadb.pid'
-      mysql_databases:
-        - name: 'keystone'
-      mysql_users:
-        - name: 'keystone'
-          password: 'keystonepassword'
-          priv: 'keystone.*:ALL'
-          host: '%'
-        - name: 'keystone'
-          password: 'keystonepassword'
-          priv: 'keystone.*:ALL'
-          host: 'localhost'
+    - name: Set facts for mysql role on RedHat based system
+      set_fact:
+        mysql_root_password: 'mysqlpassword'
+        mysql_bind_address: '0.0.0.0'
+        mysql_innodb_file_per_table: 'innodb_file_per_table'
+        mysql_daemon: 'mariadb'
+        mysql_socket: '/var/lib/mysql/mysql.sock'
+        mysql_log_error: '/var/log/mariadb/mariadb.log'
+        mysql_syslog_tag: 'mariadb'
+        mysql_pid_file: '/var/run/mariadb/mariadb.pid'
+        mysql_databases:
+          - name: 'keystone'
+        mysql_users:
+          - name: 'keystone'
+            password: 'keystonepassword'
+            priv: 'keystone.*:ALL'
+            host: '%'
+          - name: 'keystone'
+            password: 'keystonepassword'
+            priv: 'keystone.*:ALL'
+            host: 'localhost'
       when: ansible_os_family == 'RedHat'
+
+  roles:
+    - role: mysql
 
     - role: openstack-keystone
       openstack_keystone_run_sanity_check: True

--- a/tests/test_common.yml
+++ b/tests/test_common.yml
@@ -7,6 +7,7 @@
     - name: Update local apt cache (Ubuntu)
       apt:
         update_cache: True
+      changed_when: False
       when: ansible_os_family == 'Debian'
 
     - name: Install policycoreutils-python


### PR DESCRIPTION
On Ansbile 2.2, `mysql` role will not work anymore with the current
style of parameter passing.  Fix will be to pass all parameters to
`mysql` role regardless of the `ansible_os_family`.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>